### PR TITLE
RESET: confirm before delete; preserve ASM via sessionStorage

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,8 +27,9 @@
     <div id="row_2_col_2" style="height: 100%; width: 100%;">
         <div id="convertControl">
             <button id="Convert" class="primary-btn" >Convert</button>
+            <button id="RESET" class="primary-btn" type="button">RESET (New ASM Program)</button>
 
-            <button id="RESET" class="primary-btn" onclick="location.reload();">RESET (New ASM Program)</button>
+           
         </div>
     </div>
     

--- a/script.js
+++ b/script.js
@@ -1,148 +1,184 @@
-const tabPrograms = document.getElementById('tabPrograms');
-const tabInstructions = document.getElementById('tabInstructions');
-const tabContent = document.getElementById('tabContent');
+"use strict";
 
+/* -----------------------------
+   Visual helpers (kept as-is)
+--------------------------------*/
 function flashElement(elementId) {
-    const element = document.getElementById(elementId);
-    if (element) {
-        // Remove the class if already present
-        element.classList.remove('highlight-flash');
-        void element.offsetWidth; // Trigger reflow to restart animation
-        element.classList.add('highlight-flash');
-    }
+  const el = document.getElementById(elementId);
+  if (!el) return;
+  el.classList.remove("highlight-flash");
+  void el.offsetWidth; // restart CSS animation
+  el.classList.add("highlight-flash");
 }
 
+function flashButton(buttonId) {
+  const btn = document.getElementById(buttonId);
+  if (!btn) return;
+  btn.classList.add("highlight-flash");
+  setTimeout(() => btn.classList.remove("highlight-flash"), 5000);
+}
 
-//document.getElementById('stackDisplay').innerText = 'Updated stack contents...';
+function disableConvertButton() {
+  const btn = document.getElementById("Convert");
+  if (!btn) return;
+  btn.disabled = true;
+  btn.innerText = " Converted ";
+  flashButton("RUN_NEXT"); // keep your flashing on RUN_NEXT
+}
 
+/* -----------------------------
+   Tiny helpers
+--------------------------------*/
+const $ = (id) => document.getElementById(id);
 
-document.getElementById('Convert').addEventListener('click', () => {
-    const inputASM = document.getElementById('InputASM').value;
-    if (!inputASM.trim()) {
-        alert("Please provide an ASM program to convert.");
-        return;
-    }
+/* -----------------------------
+   RESET: preserve ASM across reload (unless user confirms delete)
+--------------------------------*/
+const S16_KEEP = "s16-asm-keep";
+const S16_TEXT = "s16-asm-text";
+function getAsmEl() { return $("InputASM"); }
+function readAsm()   { return (getAsmEl()?.value ?? ""); }
+function writeAsm(t) { const el = getAsmEl(); if (el) el.value = t; }
 
-    try {
-        const assembledProgram = assemble(inputASM); // Convert ASM to JSON
-        loadProgram(assembledProgram);
-    } catch (error) {
-        alert(`Error during assembly: ${error.message}`);
-    }
-
-    disableConvertButton();
-
-    // ✅ SHOW "RUN NEXT" & "RESET" BUTTONS AFTER CONVERT CLICK
-    document.getElementById('RUN_NEXT').style.display = 'inline-block';
-    document.getElementById('RESET').style.display = 'inline-block';
-
-    // ❌ HIDE "CONVERT" BUTTON AFTER CLICK
-    document.getElementById('Convert').style.display = 'none';
-});
-
-
-
-
-
-document.getElementById('RUN_NEXT').addEventListener('click', () => {
-    executeNext(); 
-});
-
-
+/* -----------------------------
+   Content loaders
+--------------------------------*/
 function loadSamplePrograms() {
-    import('./Sample_program.js').then(module => {
-        tabContent.innerHTML = module.default.map(program => `
-            <h3>${program.name}</h3>
-            <pre><code>${program.code.trim()}</code></pre>
-            <hr>
-        `).join('');
-    }).catch(err => {
-        tabContent.innerHTML = `<p>Error loading sample programs: ${err.message}</p>`;
-    });
+  const tabContent = $("tabContent");
+  if (!tabContent) return;
+  import("./Sample_program.js").then((module) => {
+    const data = module?.default ?? [];
+    tabContent.innerHTML = data.map(program => `
+      <h3>${program.name}</h3>
+      <pre><code>${program.code.trim()}</code></pre>
+      <hr>
+    `).join("");
+  }).catch(err => {
+    tabContent.innerHTML = `<p>Error loading sample programs: ${err.message}</p>`;
+  });
 }
 
 function loadInstructionSet() {
-    import('./Sample_instructions.js').then(module => {
-        tabContent.innerHTML = module.default.map(instruction => `
-            <h3>${instruction.name}</h3>
-            <p><strong>Syntax:</strong> <code>${instruction.syntax}</code></p>
-            <p><strong>Description:</strong> ${instruction.description}</p>
-            <pre><code>${instruction.example}</code></pre>
-            <hr>
-        `).join('');
-    }).catch(err => {
-        tabContent.innerHTML = `<p>Error loading instruction set: ${err.message}</p>`;
-    });
+  const tabContent = $("tabContent");
+  if (!tabContent) return;
+  import("./Sample_instructions.js").then((module) => {
+    const data = module?.default ?? [];
+    tabContent.innerHTML = data.map(instruction => `
+      <h3>${instruction.name}</h3>
+      <p><strong>Syntax:</strong> <code>${instruction.syntax}</code></p>
+      <p><strong>Description:</strong> ${instruction.description}</p>
+      <pre><code>${instruction.example}</code></pre>
+      <hr>
+    `).join("");
+  }).catch(err => {
+    tabContent.innerHTML = `<p>Error loading instruction set: ${err.message}</p>`;
+  });
 }
 
-// Add event listeners to tabs
-tabPrograms.addEventListener('click', () => {
-    tabPrograms.classList.add('active');
-    tabInstructions.classList.remove('active');
-    loadSamplePrograms();
-});
-
-tabInstructions.addEventListener('click', () => {
-    tabInstructions.classList.add('active');
-    tabPrograms.classList.remove('active');
-    loadInstructionSet();
-});
-
-document.getElementById('tabManual').addEventListener('click', () => {
-    document.getElementById('tabManual').classList.add('active');
-    document.getElementById('tabPrograms').classList.remove('active');
-    document.getElementById('tabInstructions').classList.remove('active');
-
-    // Convert Markdown-style text to HTML with headers and line breaks
-    const formattedManual = UserManual
-        .replace(/## (.*?)\n/g, "<h2>$1</h2>\n")  // Convert ## to <h2>
-        .replace(/# (.*?)\n/g, "<h1>$1</h1>\n")   // Convert # to <h1>
-        .replace(/\n/g, "<br>");                  // Convert remaining new lines to <br>
-
-    document.getElementById('tabContent').innerHTML = formattedManual;
-});
-
-
-loadSamplePrograms();
-
-function disableConvertButton() 
-{
-    const button = document.getElementById('Convert');
-    button.disabled = true; // Disable the button
-    button.innerText = " Converted "; // Optionally change the button text
-    flashButton('RUN_NEXT'); // Add flashing animation to RUN_NEXT button
-}
-
-
-function flashButton(buttonId) {
-    const button = document.getElementById(buttonId);
-    if (!button) return; // Exit if the button doesn't exist
-
-    // Add the highlight-flash class to start the animation
-    button.classList.add('highlight-flash');
-
-    // Remove the class after the animation finishes (5 cycles * 1s = 5 seconds)
-    setTimeout(() => {
-        button.classList.remove('highlight-flash');
-    }, 5000); // Adjust the timeout duration to match the animation time
-}
-
-// Call the function to flash the RUN_NEXT button
-flashButton('Convert');
-
-
+/* -----------------------------
+   Wire everything after DOM is ready
+--------------------------------*/
 document.addEventListener("DOMContentLoaded", () => {
-    const manualButton = document.getElementById("tabManual");
+  const btnConvert      = $("Convert");
+  const btnRunNext      = $("RUN_NEXT");
+  const btnReset        = $("RESET");
+  const tabPrograms     = $("tabPrograms");
+  const tabInstructions = $("tabInstructions");
+  const tabManual       = $("tabManual");
+  const tabContent      = $("tabContent");
 
-    if (manualButton) {
-        // Add the blinking effect
-        manualButton.classList.add("blink");
+  // Restore ASM if preserved
+  if (sessionStorage.getItem(S16_KEEP) === "1") {
+    writeAsm(sessionStorage.getItem(S16_TEXT) || "");
+  }
+  sessionStorage.removeItem(S16_KEEP);
+  sessionStorage.removeItem(S16_TEXT);
 
-        // Stop blinking after 5 seconds
-        setTimeout(() => {
-            manualButton.classList.remove("blink");
-        }, 5000);
-    } else {
-        console.error("tabManual button not found! Check if the ID is correct in index.html.");
+  // Convert
+  btnConvert?.addEventListener("click", () => {
+    const inputASM = readAsm();
+    if (!inputASM.trim()) {
+      alert("Please provide an ASM program to convert.");
+      return;
     }
+    try {
+      // assemble() and loadProgram() must exist globally in your project
+      const assembledProgram = assemble(inputASM);
+      loadProgram(assembledProgram);
+    } catch (error) {
+      alert(`Error during assembly: ${error.message}`);
+      return;
+    }
+
+    disableConvertButton();
+    if (btnRunNext) btnRunNext.style.display = "inline-block";
+    if (btnReset)   btnReset.style.display   = "inline-block";
+    btnConvert.style.display = "none";
+  });
+
+  // Run Next
+  btnRunNext?.addEventListener("click", () => {
+    // executeNext() must exist globally in your project
+    executeNext();
+  });
+
+  // Tabs
+  tabPrograms?.addEventListener("click", () => {
+    tabPrograms.classList.add("active");
+    tabInstructions?.classList.remove("active");
+    loadSamplePrograms();
+  });
+
+  tabInstructions?.addEventListener("click", () => {
+    tabInstructions.classList.add("active");
+    tabPrograms?.classList.remove("active");
+    loadInstructionSet();
+  });
+
+  tabManual?.addEventListener("click", () => {
+    tabManual.classList.add("active");
+    tabPrograms?.classList.remove("active");
+    tabInstructions?.classList.remove("active");
+
+    // UserManual must be defined (e.g., loaded via <script> before this file)
+    const manual = (typeof window.UserManual === "string") ? window.UserManual : "";
+    const formattedManual = manual
+      .replace(/## (.*?)\n/g, "<h2>$1</h2>\n")
+      .replace(/# (.*?)\n/g, "<h1>$1</h1>\n")
+      .replace(/\n/g, "<br>");
+    if (tabContent) tabContent.innerHTML = formattedManual || "<p>Manual not loaded.</p>";
+  });
+
+  // Initial content & small effects
+  loadSamplePrograms();      // default view
+  flashButton("Convert");    // flash Convert on page load
+
+  // Blink the Manual tab briefly
+  if (tabManual) {
+    tabManual.classList.add("blink");
+    setTimeout(() => tabManual.classList.remove("blink"), 5000);
+  }
+
+  // RESET: ask before deleting ASM, preserve across reload if NO
+  btnReset?.addEventListener("click", () => {
+    const asm = readAsm();
+    const hasText = asm.trim().length > 0;
+    let wantsDelete = false;
+
+    if (hasText) {
+      wantsDelete = window.confirm(
+        "Reset will reload the simulator.\n If you also want to keep the ASM program text Click on Cancel."
+      );
+    }
+
+    if (!wantsDelete && hasText) {
+      sessionStorage.setItem(S16_KEEP, "1");
+      sessionStorage.setItem(S16_TEXT, asm);
+    } else {
+      sessionStorage.removeItem(S16_KEEP);
+      sessionStorage.removeItem(S16_TEXT);
+    }
+
+    location.reload();
+  });
 });


### PR DESCRIPTION
- Removes inline `onclick` from RESET in index.html; binds events after DOM is ready
- Adds confirm dialog on RESET; preserves #InputASM across reload using sessionStorage when user clicks "No"
- Keeps flash helpers (flashButton/flashElement); shows RUN_NEXT/RESET after Convert; hides Convert
- Hardened loaders (re-query tabContent); initial content set to Sample Programs
